### PR TITLE
Don't use __builtin_rotateleft32 for Intel on OSX

### DIFF
--- a/src/tests/hash_functions/nmhash.h
+++ b/src/tests/hash_functions/nmhash.h
@@ -51,7 +51,8 @@ extern "C" {
 #endif
 
 #if defined(__has_builtin)
-#  if __has_builtin(__builtin_rotateleft32)
+#  if __has_builtin(__builtin_rotateleft32) \
+    && !(defined(__INTEL_COMPILER) && defined(__APPLE__))
 #    define NMH_rotl32 __builtin_rotateleft32 /* clang */
 #  endif
 #endif

--- a/src/tests/hash_functions/nmhash_scalar.h
+++ b/src/tests/hash_functions/nmhash_scalar.h
@@ -51,7 +51,8 @@ extern "C" {
 #endif
 
 #if defined(__has_builtin)
-#  if __has_builtin(__builtin_rotateleft32)
+#  if __has_builtin(__builtin_rotateleft32) \
+    && !(defined(__INTEL_COMPILER) && defined(__APPLE__))
 #    define NMH_rotl32 __builtin_rotateleft32 /* clang */
 #  endif
 #endif


### PR DESCRIPTION
> [Here](https://community.intel.com/t5/Intel-C-Compiler/Missing-C-library-function-builtin-rotateleft32/m-p/1343356) is the answer on the Intel forum.
>
> It seems that Intel 2021.4 works fine on their side. I am not sure how to test it further?

@wclodius2 @jvdp1 Well, seems like it is still broken on our side. Let's line it up with preprocessor, like one does in C, and move on. Doesn't sound like a problem worth dwelling on.

Successful run: https://github.com/awvwgk/fortran-stdlib/runs/4552708255?check_suite_focus=true